### PR TITLE
增加参数-尺寸单位（measure）

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Property|Type|Default|Description
 ---|---|---|---
 width|number|400|width of dialog
 height|number|240|height of dialog
+measure|string|px|measure of width and height
 onClose|func|/|onClose handler function
 visible|bool|false|whether to show dialog
 showMask|bool|true|whether to show mask

--- a/src/rodal.js
+++ b/src/rodal.js
@@ -16,12 +16,14 @@ const propTypes = {
     showMask        : PropTypes.bool,
     showCloseButton : PropTypes.bool,
     animation       : PropTypes.string,
-    duration        : PropTypes.number
+    duration        : PropTypes.number,
+    measure         : PropTypes.string
 };
 
 const defaultProps = {
     width           : 400,
     height          : 240,
+    measure         : 'px',
     visible         : false,
     showMask        : true,
     showCloseButton : true,
@@ -34,10 +36,10 @@ const Dialog = props => {
     const className = `rodal-dialog rodal-${props.animation}-${props.animationType}`;
     const CloseButton = props.showCloseButton ? <span className="rodal-close" onClick={props.onClose} /> : null;
     const style = {
-        width                   : props.width,
-        height                  : props.height,
-        marginTop               : - props.height / 2 - 20,
-        marginLeft              : - props.width / 2,
+        width                   : (props.width) + measure,
+        height                  : (props.height) + measure,
+        marginTop               : (- props.height / 2) + measure,
+        marginLeft              : (- props.width / 2) + measure,
         animationDuration       : props.duration + 'ms',
         WebkitAnimationDuration : props.duration + 'ms'
     };


### PR DESCRIPTION
很多响应式或者H5页面很多用到了rem等尺寸单位，如果只是用px作为唯一的单位，不能够很好的兼容到那些应用，所以增加measure参数，默认还是px