### PR TITLE
Using built-in onAnimationEnd event from React v15

### DIFF
--- a/src/rodal.js
+++ b/src/rodal.js
@@ -87,15 +87,9 @@ class Rodal extends Component {
     }
 
     leave() {
-        if (this.animationEvents) {
-            this.setState({
-                animationType: 'leave'
-            });
-        } else {
-            this.setState({
-                isShow: false
-            })
-        }
+        this.setState({
+            animationType: 'leave'
+        });
     }
 
     animationEnd() {

--- a/src/rodal.js
+++ b/src/rodal.js
@@ -3,8 +3,6 @@
  * =============================== */
 
 import React                from 'react';
-import ReactDOM             from 'react-dom';
-import addEndEventListener  from './animationEvents';
 import './rodal.css';
 
 const { PropTypes, Component } = React;
@@ -57,6 +55,7 @@ class Rodal extends Component {
     constructor(props) {
         super(props);
 
+        this.animationEnd = this.animationEnd.bind(this);
         this.state = {
             isShow        : false,
             animationType : 'leave'
@@ -67,22 +66,8 @@ class Rodal extends Component {
      * add animation event listener
      */
     componentDidMount() {
-        this.animationEvents = addEndEventListener(
-            ReactDOM.findDOMNode(this),
-            this.animationEnd.bind(this)
-        );
-
         if (this.props.visible) {
             this.enter();
-        }
-    }
-
-    /**
-     * remove animation event listener
-     */
-    componentWillUnmount() {
-        if (this.animationEvents) {
-            this.animationEvents.remove();
         }
     }
 
@@ -113,12 +98,7 @@ class Rodal extends Component {
         }
     }
 
-    animationEnd(e) {
-        const node = ReactDOM.findDOMNode(this);
-        if (e && e.target !== node) {
-            return;
-        }
-
+    animationEnd() {
         if (this.state.animationType === 'leave') {
             this.setState({
                 isShow: false
@@ -135,7 +115,7 @@ class Rodal extends Component {
         };
 
         return (
-            <div style={style} className={"rodal rodal-fade-" + this.state.animationType}>
+            <div style={style} className={"rodal rodal-fade-" + this.state.animationType} onAnimationEnd={ this.animationEnd }>
                 {mask}
                 <Dialog {...this.props} animationType={this.state.animationType}>
                     {this.props.children}


### PR DESCRIPTION
Removes need for animationEvent util and ReactDOM findDOMNode. 

However will break support for React 0.14 since this.state.isShow isn't able to be set to false after animation end. Animations still fire, just the modal will sit on top of the page with no opacity preventing anything beneath it to be clicked. (Could possibly add pointer-events: none to element to allow clicks through)
