### PR TITLE
Add animationEnd event target check

### DIFF
--- a/lib/rodal.js
+++ b/lib/rodal.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; /* ===============================
-                                                                                                                                                                                                                                                                   * Rodal v1.5.4 http://rodal.cn
+                                                                                                                                                                                                                                                                   * Rodal v1.5.5 http://rodal.cn
                                                                                                                                                                                                                                                                    * =============================== */
 
 var _react = require('react');
@@ -77,7 +77,7 @@ var Rodal = function (_React$Component) {
             if (_this.props.closeOnEsc && event.keyCode === 27) {
                 _this.props.onClose();
             }
-        }, _this.animationEnd = function () {
+        }, _this.animationEnd = function (event) {
             if (_this.state.animationType === 'leave') {
                 _this.setState({ isShow: false });
             } else if (_this.props.closeOnEsc) {
@@ -86,7 +86,10 @@ var Rodal = function (_React$Component) {
 
             var onAnimationEnd = _this.props.onAnimationEnd;
 
-            onAnimationEnd && onAnimationEnd();
+
+            if (event.target == _this.el) {
+                onAnimationEnd && onAnimationEnd();
+            }
         }, _temp), _possibleConstructorReturn(_this, _ret);
     }
 

--- a/src/rodal.js
+++ b/src/rodal.js
@@ -105,7 +105,7 @@ class Rodal extends React.Component {
         }
     }
 
-    animationEnd = () => {
+    animationEnd = event => {
         if (this.state.animationType === 'leave') {
             this.setState({ isShow: false });
         } else if (this.props.closeOnEsc) {
@@ -113,7 +113,10 @@ class Rodal extends React.Component {
         }
 
         const { onAnimationEnd } = this.props;
-        onAnimationEnd && onAnimationEnd();
+
+        if (event.target == this.el) {
+            onAnimationEnd && onAnimationEnd();
+        }
     }
 
     render() {
@@ -127,7 +130,7 @@ class Rodal extends React.Component {
         };
 
         return (
-            <div 
+            <div
                 style={style}
                 className={"rodal rodal-fade-" + state.animationType + ' ' + props.className}
                 onAnimationEnd={this.animationEnd}


### PR DESCRIPTION
Problem: The animationEnd handler catches both .rodal and .rodal-dialog DOM elements' events. And the animationEnd callback is called twice because of that.

My commit adds an event target check so that the animationEnd callback is called only once for an animation.