### PR TITLE
accessibility-for-close-button

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ width|number|400|width of dialog
 height|number|240|height of dialog
 measure|string|px|measure of width and height
 onClose|func|/|handler called onClose of modal
-onCloseKeyPress|func|/|handler for keyboard event on close button
 onAnimationEnd|func|/|handler called onEnd of animation
 visible|bool|false|whether to show dialog
 showMask|bool|true|whether to show mask

--- a/README.md
+++ b/README.md
@@ -34,12 +34,18 @@ class App extends React.Component {
         this.setState({ visible: false });
     }
 
+    onKeyboardKeyPress = (event) => {
+        if (event.which === 13) { // Closing on only clicking on Enter
+            this.hide();
+        }
+    }
+
     render() {
         return (
             <div>
                 <button onClick={this.show.bind(this)}>show</button>
 
-                <Rodal visible={this.state.visible} onClose={this.hide.bind(this)}>
+                <Rodal visible={this.state.visible} onClose={this.hide.bind(this)} onCloseKeyPress={this.onKeyboardKeyPress}>
                     <div>Content</div>
                 </Rodal>
             </div>
@@ -56,6 +62,7 @@ width|number|400|width of dialog
 height|number|240|height of dialog
 measure|string|px|measure of width and height
 onClose|func|/|handler called onClose of modal
+onCloseKeyPress|func|/|handler for keyboard event on close button
 onAnimationEnd|func|/|handler called onEnd of animation
 visible|bool|false|whether to show dialog
 showMask|bool|true|whether to show mask

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ class App extends React.Component {
     }
 
     onKeyboardKeyPress = (event) => {
-        if (event.which === 13) { // Closing on only clicking on Enter
+        if (event.which === 13) {
             this.hide();
         }
     }

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -26,6 +26,12 @@ class App extends React.Component {
         this.setState({ visible: false });
     }
 
+    onKeyPressHide = (event) => {
+        if (event.which === 13) {
+            this.hide();
+        }
+    }
+
     render () {
         const { visible, animation } = this.state;
         const types = ['zoom', 'fade', 'flip', 'door', 'rotate', 'slideUp', 'slideDown', 'slideLeft', 'slideRight'];
@@ -50,6 +56,7 @@ class App extends React.Component {
                 </div>
                 <Rodal visible={visible}
                        onClose={this.hide}
+                       onCloseKeyPress={this.onKeyPressHide}
                        animation={animation}
                        closeOnEsc
                 >

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -56,7 +56,6 @@ class App extends React.Component {
                 </div>
                 <Rodal visible={visible}
                        onClose={this.hide}
-                       onCloseKeyPress={this.onKeyPressHide}
                        animation={animation}
                        closeOnEsc
                 >

--- a/src/rodal.js
+++ b/src/rodal.js
@@ -15,8 +15,8 @@ const Dialog = props => {
     const animation = (props.animationType === 'enter' ? props.enterAnimation : props.leaveAnimation) || props.animation;
     const className = `rodal-dialog rodal-${animation}-${props.animationType}`;
     const CloseButton = props.showCloseButton ? <span className="rodal-close" onClick={props.onClose} onKeyPress={(event) => {
-        if (props.onCloseKeyPress) {
-            props.onCloseKeyPress(event);
+        if (props.onClose && event.which === 13) {
+            props.onClose();
         }
     }} tabIndex={0} /> : null;
     const { width, height, measure, duration, customStyles } = props;
@@ -55,7 +55,6 @@ class Rodal extends React.Component {
         customStyles     : PropTypes.object,
         customMaskStyles : PropTypes.object,
         onClose          : PropTypes.func.isRequired,
-        onCloseKeyPress  : PropTypes.func,
         onAnimationEnd   : PropTypes.func
     };
 

--- a/src/rodal.js
+++ b/src/rodal.js
@@ -14,7 +14,11 @@ const IS_IE_9 = UA && UA.indexOf('msie 9.0') > 0;
 const Dialog = props => {
     const animation = (props.animationType === 'enter' ? props.enterAnimation : props.leaveAnimation) || props.animation;
     const className = `rodal-dialog rodal-${animation}-${props.animationType}`;
-    const CloseButton = props.showCloseButton ? <span className="rodal-close" onClick={props.onClose} tabIndex={0} /> : null;
+    const CloseButton = props.showCloseButton ? <span className="rodal-close" onClick={props.onClose} onKeyPress={(event) => {
+        if (props.onCloseKeyPress) {
+            props.onCloseKeyPress(event);
+        }
+    }} tabIndex={0} /> : null;
     const { width, height, measure, duration, customStyles } = props;
     const style = {
         width: width + measure,
@@ -51,6 +55,7 @@ class Rodal extends React.Component {
         customStyles     : PropTypes.object,
         customMaskStyles : PropTypes.object,
         onClose          : PropTypes.func.isRequired,
+        onCloseKeyPress  : PropTypes.func,
         onAnimationEnd   : PropTypes.func
     };
 

--- a/src/rodal.js
+++ b/src/rodal.js
@@ -14,7 +14,7 @@ const IS_IE_9 = UA && UA.indexOf('msie 9.0') > 0;
 const Dialog = props => {
     const animation = (props.animationType === 'enter' ? props.enterAnimation : props.leaveAnimation) || props.animation;
     const className = `rodal-dialog rodal-${animation}-${props.animationType}`;
-    const CloseButton = props.showCloseButton ? <span className="rodal-close" onClick={props.onClose} /> : null;
+    const CloseButton = props.showCloseButton ? <span className="rodal-close" onClick={props.onClose} tabIndex={0} /> : null;
     const { width, height, measure, duration, customStyles } = props;
     const style = {
         width: width + measure,


### PR DESCRIPTION
Resolves #52 

Issue: Navigation with keyboard was not available i.e. accessibility. With help of `tabindex` property on html tags it can be made interactive for accessibility purposes.

- Added `tabIndex` for navigation with keyboard tab button to go to close button
- Added optional prop function `onCloseKeyPress` for giving consumer ability to handle keypress event.